### PR TITLE
Reduce allowed length of prefix used for obs resource

### DIFF
--- a/tools/setup-3p-obs-infra/cluster-dataCollectionRules.bicep
+++ b/tools/setup-3p-obs-infra/cluster-dataCollectionRules.bicep
@@ -8,8 +8,8 @@ param clusterName string
 
 @description('Prefix to apply to all monitor resources')
 @minLength(1)
-@maxLength(50)
-param prefix string = '${clusterName}-obs-${substring(uniqueString(resourceGroup().id), 0, 3)}'
+@maxLength(18)
+param prefix string = '${clusterName}-${substring(uniqueString(resourceGroup().id), 0, 3)}'
 
 @description('Region where the Azure Monitor is located')
 param azureMonitorLocation string


### PR DESCRIPTION
1. Reduce max length of prefix to account for max of 44 characters allowed for names of resources created using the prefix variable in cluster-dataCollectionRules.bicep.
2. Remove 'obs' from prefix to reduce likelihood of encountering error caused by exceeding max resource name length.